### PR TITLE
docs: fix syntax error "usage with lazyvim" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ return {
             inlayHints = {
               includeInlayParameterNameHints = "all", -- 'none' | 'literals' | 'all'
               includeInlayParameterNameHintsWhenArgumentMatchesName = true,
-              includeInlayVariableTypeHints = true
+              includeInlayVariableTypeHints = true,
 
               includeInlayFunctionParameterTypeHints = true,
               includeInlayVariableTypeHintsWhenTypeMatchesName = true,


### PR DESCRIPTION
## WHY
I'm a new neovim user, and tried to enable inlay hints. Looks like the example was missing a comma.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
